### PR TITLE
Update scraper for council website changes

### DIFF
--- a/lib/epathway_scraper/page/list_select.rb
+++ b/lib/epathway_scraper/page/list_select.rb
@@ -106,7 +106,7 @@ module EpathwayScraper
       # Fake that we're running javascript by picking out the javascript redirect
       def self.follow_javascript_redirect(page, agent)
         match = page.body.match(/window.location.href='(.*)';/)
-        raise "Could not find javascript redirect" if match.nil?
+        return page if match.nil?
 
         redirected_url = match[1]
         agent.get(redirected_url)


### PR DESCRIPTION
According to the last run on morph the following failed to be scraped:

`bendigo`
`east_gippsland`
`gladstone`
`greater_shepparton`
`inverell`
`latrobe`
`monash`
`mooney_valley`
`moreland`
`nillumbik`
`port_phillip`
`south_gippsland`

With this PR, the following council websites can be scraped:

`bendigo`
`east_gippsland`
`gladstone`
`greater_shepparton`
`inverell`
`monash`
`mooney_valley`
`moreland`
`nillumbik`
`south_gippsland`

The following councils still cannot be scraped:
`latrobe`
`port_phillip`
