### PR TITLE
Added Gosford council to the scraper

### DIFF
--- a/lib/epathway_scraper/authorities.rb
+++ b/lib/epathway_scraper/authorities.rb
@@ -171,6 +171,12 @@ module EpathwayScraper
       state: "VIC",
       lists: [:all],
       max_pages: 20
+    },
+    gosford: {
+      url: "https://eservices.centralcoast.nsw.gov.au/ePathway/Production",
+      state: "NSW",
+      lists: [:all],
+      disable_ssl_certificate_check: true
     }
   }.freeze
 end


### PR DESCRIPTION
Added the Gosford scraper as it was removed from the multiple_icon scraper.

Fixes issue [#417](https://github.com/planningalerts-scrapers/issues/issues/417)

Mentioned in PR [#15](https://github.com/planningalerts-scrapers/multiple_icon/pull/15) 

