### PR TITLE
Disabled SSL cert check for central coast.

### DIFF
--- a/lib/epathway_scraper/authorities.rb
+++ b/lib/epathway_scraper/authorities.rb
@@ -6,7 +6,8 @@ module EpathwayScraper
     central_coast: {
       url: "https://eservices.centralcoast.nsw.gov.au/ePathway/Production",
       state: "NSW",
-      lists: [:advertising]
+      lists: [:advertising],
+      disable_ssl_certificate_check: true
     },
     ballarat: {
       url: "https://eservices.ballarat.vic.gov.au/ePathway/Production",


### PR DESCRIPTION
Fixes central coast council scraper